### PR TITLE
Add page for last year's exhibitors

### DIFF
--- a/content/previous.md
+++ b/content/previous.md
@@ -1,9 +1,8 @@
 ---
 title: Previous
-layout: previousExhibitors
-description: Page
+layout: Previous
+description: View last year's exhibitors at the fair
 menuPage: false
 priority: '1'
-header: /assets/53comp.png
+header: /assets/images/header-images/About.jpg
 ---
-Here you have info!

--- a/src/components/ExhibitorList/exhibitorlist.scss
+++ b/src/components/ExhibitorList/exhibitorlist.scss
@@ -112,6 +112,14 @@
 }
 */
 
+.search {
+  padding-bottom: 1em;
+}
+
+.filter-special.display-none, .filters.display-none {
+  display: none;
+}
+
 .exhibitors .search-container{
   margin: auto;
 	padding: 0.1em 2em 0.5em 2em;
@@ -282,7 +290,6 @@
   overflow: hidden;
   border-radius: 4px;
   margin-bottom: 0.5em;
-  border: solid;
   border-width: thin;
   width: 6.6em;
   height: 7em;

--- a/src/components/ExhibitorList/index.js
+++ b/src/components/ExhibitorList/index.js
@@ -25,6 +25,7 @@ class ExhibitorList extends React.Component {
   constructor(props) {
     super(props); // adopts parent qualities
     this.state = {
+      previousYear: new Date(new Date().setFullYear(new Date().getFullYear() - 1)).getFullYear().toString(), //get the previous year
       exhibitors: [],  // json object
       exhibitorList: [], //displayed exhibitors
       showModal: false, //show individual company card
@@ -305,7 +306,7 @@ class ExhibitorList extends React.Component {
 
   //currently only deals w/ getting data from api (unsure)
   componentDidMount() {  // only called when exhibitor page is created or updated.
-    axios.get(ais + 'api/exhibitors?img_placeholder=true')  // fetch data witt promise (then) and res(ult)
+    axios.get(ais + `api/exhibitors?img_placeholder=true${this.props.lastYear ? '&year='+this.state.previousYear : ''}`)
       .then((res) => {
         let exhibitors = res.data;  // create variable and store result within parameter data
         exhibitors.sort((a, b) => a.name.localeCompare(b.name));
@@ -354,8 +355,8 @@ class ExhibitorList extends React.Component {
             </div>
             <h1 className="modal-title">{exhibitor.name}</h1>
             <div>
-              {exhibitor.vyer_position ? <h3 className="links"><a href={exhibitor.vyer_position} target="_blank">Click for Map position</a></h3> : null}
-              {exhibitor.fair_location ? <h3 id="fair-location">{exhibitor.fair_location}</h3> : null}
+              {exhibitor.vyer_position && !this.props.lastYear ? <h3 className="links"><a href={exhibitor.vyer_position} target="_blank">Click for Map position</a></h3> : null}
+              {exhibitor.fair_location && !this.props.lastYear ? <h3 id="fair-location">{exhibitor.fair_location}</h3> : null}
               {exhibitor.company_website ? <h3 className="links"><a href={exhibitor.company_website} target="_blank">{exhibitor.name + " Website"}</a></h3> : null}
               {exhibitor.flyer ? <h3 className="links"><a href={ais + exhibitor.flyer} target="_blank">{exhibitor.name + " Digital Flyer"}</a></h3> : null}
             </div>
@@ -372,7 +373,6 @@ class ExhibitorList extends React.Component {
               </div>
 
               <div className="description-container">
-                {/*<h3>{exhibitor.name}</h3>*/}
                 <p className="purpose-text"><b>{exhibitor.purpose}</b></p>
                 <br />
                 <div className="description">
@@ -527,13 +527,6 @@ class ExhibitorList extends React.Component {
     this.setState({ sustainabilitysrc })
   }
 
-  // groupFilter(group) {
-  //     let groupfilter = this.state.groupfilter[value];
-  //     if (groupfilter[group] === false) { groupfilter[group] = true }
-  //     else if (groupfilter[group] === true) { groupfilter[group] = false }
-  //     this.setState({ groupfilter[0] })
-  // }
-
   //build options for dropdown filters
   buildOptions(array) {
     var listitems = []
@@ -648,85 +641,78 @@ class ExhibitorList extends React.Component {
             <div className="armadaRainbow easterEggPosition" />
           </EasterEgg>
 
-          <h1>Exhibitors</h1>
-          <p><span className="bold" >Sustainability & Diversity</span> form the core values at the heart of our organization. To highlight our core values, we have chosen to dedicate focus areas of the fair called Green Room and Diversity Room. If an exhibitor is tagged with one of the images below, they are in one of these rooms! These are the exhibitors for last year's fair!</p>
+          <h1>{this.props.lastYear ? "Last Year's " : ""}Exhibitors</h1>
+          <br/>
+          <p style={{paddingBottom: this.props.lastYear ? '1em' : {}}}>{this.props.lastYear ? `These are the exhibitors from the ${this.state.previousYear} fair.` : <span><span className="bold" >Sustainability & Diversity</span> form the core values at the heart of our organization. To highlight our core values, we have chosen to dedicate focus areas of the fair called Green Room and Diversity Room. If an exhibitor is tagged with one of the images below, they are in one of these rooms!</span>}</p>
           {this.state.showModal ? (this.displayExhibitor(exhibitorToDisplay)) : null}
 
-          {/*TODO: remove blue box around special filters*/}
-          <div className="filter-special">
-
-            <input id="diversity" type="image" alt='diversity filter' src={this.state.diversitysrc}
-              onClick={() => this.diversityFilter()}
-            //onMouseEnter={() => this.cssShine('purple')}
-            //onMouseLeave={() => this.cssShineOff()}
-            />
-
-            <input id="sustainability" type="image" alt='sustainability filter' src={this.state.sustainabilitysrc}
-              onClick={() => this.sustainabilityFilter()}
-            //onMouseEnter={() => this.cssShine('green')}
-            //onMouseLeave={() => this.cssShineOff()}
-            />
-
+          <div className={`filter-special ${this.props.lastYear ? 'display-none' : ''}`}>
+            <input id="diversity" type="image" alt='diversity filter' src={this.state.diversitysrc} onClick={() => this.diversityFilter()} />
+            <input id="sustainability" type="image" alt='sustainability filter' src={this.state.sustainabilitysrc} onClick={() => this.sustainabilityFilter()} />
           </div>
 
-          <div className="search-container">
-            <input type="text"
-              placeholder="Search Exhibitors"
-              value={this.state.search}
-              onChange={this.updateSearch.bind(this)}
-            />
+          <div className="search">
+            <div className="search-container">
+              <input type="text"
+                placeholder="Search Exhibitors"
+                value={this.state.search}
+                onChange={this.updateSearch.bind(this)}
+              />
+            </div>
+            <div className={`filters ${this.props.lastYear ? 'display-none' : ''}`}>
+              <Select
+                closeMenuOnSelect={false}
+                blurInputOnSelect={false}
+                isMulti
+                isSearchable
+                name="Job filter"
+                placeholder="All Jobs"
+                options={this.state.jobs}
+                onChange={event => this.jobFilter(event)}
+                className="basic-multi-select"
+                classNamePrefix="select"
+              />
+
+              <Select
+                closeMenuOnSelect={false}
+                blurInputOnSelect={false}
+                isMulti
+                isSearchable
+                name="Sector filter"
+                placeholder="All Industries"
+                options={this.state.sectors}
+                onChange={event => this.sectorFilter(event)}
+                className="basic-multi-select"
+                classNamePrefix="select"
+              />
+
+              <Select
+                closeMenuOnSelect={false}
+                blurInputOnSelect={false}
+                isMulti
+                isSearchable
+                name="Competence filter"
+                placeholder="All Competences"
+                options={this.state.competences}
+                onChange={event => this.competenceFilter(event)}
+                className="basic-multi-select"
+                classNamePrefix="select"
+              />
+
+              <Select
+                closeMenuOnSelect={false}
+                blurInputOnSelect={false}
+                isMulti
+                isSearchable
+                name="Location filter"
+                placeholder="All Locations"
+                options={this.state.locations}
+                onChange={event => this.locationFilter(event)}
+                className="basic-multi-select"
+                classNamePrefix="select"
+              />
+            </div>
           </div>
-          <Select
-            closeMenuOnSelect={false}
-            blurInputOnSelect={false}
-            isMulti
-            isSearchable
-            name="Job filter"
-            placeholder="All Jobs"
-            options={this.state.jobs}
-            onChange={event => this.jobFilter(event)}
-            className="basic-multi-select"
-            classNamePrefix="select"
-          />
-
-          <Select
-            closeMenuOnSelect={false}
-            blurInputOnSelect={false}
-            isMulti
-            isSearchable
-            name="Sector filter"
-            placeholder="All Industries"
-            options={this.state.sectors}
-            onChange={event => this.sectorFilter(event)}
-            className="basic-multi-select"
-            classNamePrefix="select"
-          />
-
-          <Select
-            closeMenuOnSelect={false}
-            blurInputOnSelect={false}
-            isMulti
-            isSearchable
-            name="Competence filter"
-            placeholder="All Competences"
-            options={this.state.competences}
-            onChange={event => this.competenceFilter(event)}
-            className="basic-multi-select"
-            classNamePrefix="select"
-          />
-
-          <Select
-            closeMenuOnSelect={false}
-            blurInputOnSelect={false}
-            isMulti
-            isSearchable
-            name="Location filter"
-            placeholder="All Locations"
-            options={this.state.locations}
-            onChange={event => this.locationFilter(event)}
-            className="basic-multi-select"
-            classNamePrefix="select"
-          />
 
           {/* <div className="supercontainer">
               <p className="matching_link">Pssst! Find your perfect company by using Armada's new <Link className="matching_link_style" to="/matching">matching functionality!</Link></p>
@@ -769,6 +755,7 @@ class ExhibitorList extends React.Component {
 ExhibitorList.propTypes = {
   exhibitorName: PropTypes.string,
   onChangeExhibitorName: PropTypes.func,
+  lastYear: PropTypes.bool
 }
 
 let toExport;

--- a/src/components/FAQ/FAQContent.js
+++ b/src/components/FAQ/FAQContent.js
@@ -29,7 +29,7 @@ class FAQContent extends React.Component {
                                     <nav className='accordion-homepage'>
                                     {category.body.map((faq, i) => {
                                         return(
-                                            <FAQQuestion key={i} question={faq.question} answer={faq.answer}/>
+                                            <FAQQuestion key={i} question={faq.question} answer={faq.displayAnswer ? faq.displayAnswer : faq.answer}/>
                                         );
                                     })}
                                 </nav>

--- a/src/components/FAQ/index.js
+++ b/src/components/FAQ/index.js
@@ -3,25 +3,27 @@ import FAQHeader from './FAQHeader'
 import FAQContent from './FAQContent'
 import background from '../../../content/assets/faqbanner.png'
 
+//FAQ questions and answers. Only question and answer are used in search. Define displayAnswer to use elements such as link-tags in the answer.
 const faq_data = [
     {title: "ABOUT ARMADA", body: [
         {question: "What is THS Armada?", answer: "The largest student-led career fair in Scandinavia bringing together great minds from KTH and other universities and companies from around the globe. Every year since 1981 THS Armada has created a platform where students and companies can shape their future, together."},
         {question: "Where is THS Armada?", answer: "THS Armada is taking place in Nymble, KTH Entré, and KTH Library. All located on KTH Campus Valhallavägen."},
         {question: "What is the Start-up Arena by KTH Innovation?", answer: "It is a collaboration between THS Armada and KTH Innovation to showcase start-ups that have come from KTH and are looking for more students that want to join them. So take the chance to #joinastartup at KTH Entré."},
-        {question: "How can I find all the events that Armada arrange?", answer: "Head to armada.nu/events/ and sign up now! THS Armada arranges lunch lectures approximately two week prior to the fair. During the fair, THS Armada arranges Individual meetings with companies and internship pitch lectures."},
+        {question: "How can I find all the events that Armada arranges?", answer: "Head to armada.nu/events/ and sign up now! THS Armada arranges lunch lectures approximately two week prior to the fair. During the fair, THS Armada arranges Individual meetings with companies and internship pitch lectures.", displayAnswer: <span>Head to <a href="/events/">armada.nu/events</a> and sign up now! THS Armada arranges lunch lectures approximately two week prior to the fair. During the fair, THS Armada arranges Individual meetings with companies and internship pitch lectures.</span>},
     ]},
     {title: "THE FAIR", body: [
         {question: "When is the Armada fair taking place?", answer: "The Armada Career Fair takes place each year in November for 2 days. This year we will host the fair November 17-18."},
         {question: "What are the opening hours?", answer: "10.00-16.00 on November 17th and 10.00-15.00 on November 18th."},
         {question: "Does the Armada fair cost money to attend?", answer: "No, it is completely free for everyone to visit! If you are representing a company that wants to exhibit next year, contact the Project Manager at a@armada.nu."},
         {question: "I do not study at KTH, can I still attend?", answer: "Yes of course! Everybody is welcome."},
-        {question: "How many companies are coming to the Armada fair?", answer: "This year we are having 174 companies exhibiting, and many smaller startups. You can see all the exhibiting companies at armada.nu/exhibitors/"},
+        {question: "How many companies are coming to the Armada fair?", answer: "You can see all the exhibiting companies at armada.nu/exhibitors", displayAnswer: <span>You can see all the exhibiting companies at <a href="/exhibitors/">armada.nu/exhibitors</a>.</span>},
         {question: "What is the Green Room?", answer: "A place at the fair where companies that actively work with sustainability-related questions stand."},
         {question: "What is the Diversity Room?", answer: "A place at the fair where companies that actively work with diversity-related questions stand."},
+        {question: "Where can I find last year's exhibitors?", answer: "Head to armada.nu/previous to find last year's exhibitors.", displayAnswer: <span>Head to <a href="/previous/">armada.nu/previous</a> to find last year's exhibitors.</span>},
 ]},
 {title: "MAPS AND LOCATIONS", body: [
     {question: "Where are the Information Desks located?", answer: "There are two information desks. The first one is located outside KårX in Nymble and the second one is located in the Library, on the right-hand side just before entering the big hall."},
-        {question: "Where can I find a map of the exhibitor area?", answer: "Go to armada.nu/maps/ there you will find an interactive map over all exhibitors."},
+        {question: "Where can I find a map of the exhibitor area?", answer: "Go to armada.nu/maps/ there you will find an interactive map over all exhibitors.", displayAnswer: <span>Go to <a href="/maps">armada.nu/maps</a>, there you will find an interactive map over all exhibitors.</span>},
         {question: "How do I find a specific company at the fair?", answer: "You can do this in two ways, either you go to the exhibitors page, search for the company you are interested in and then click on their map position. Or you go to the map directly and search for the company there, you will then find the location of the company you are looking for."},
         {question: "Will there be any wardrobes at the fair?", answer: "Yes, there will be one wardrobe in Nymble, click here for the position, at the entrance closest to the subway and one in the library close to the information desk"},
 ]},
@@ -57,7 +59,6 @@ class FAQContainer extends React.Component {
                     <FAQHeader onQuestionUpdate={this.updateSearchResult} />   
                 </div>
                 <div >
-                
                 <FAQContent faq_data={this.state.searchResult}/>
     
                 </div>
@@ -70,7 +71,7 @@ class FAQContainer extends React.Component {
         input = input.target.value.toLowerCase()
 
         // actual result filtering
-        let copy = JSON.parse(JSON.stringify(faq_data))
+        let copy =  faq_data.map(a => Object.assign({}, a));
 
         // filter question
         copy = copy.map(group => {

--- a/src/components/FAQ/index.scss
+++ b/src/components/FAQ/index.scss
@@ -207,6 +207,10 @@ homepage .parent:first-child > h2 {
     overflow: hidden;
 }
 
+.children a {
+    color: $diversity;
+}
+
 .answer {
     font-size: 1.0rem;
     font-weight: 450;

--- a/src/layouts/Previous/index.js
+++ b/src/layouts/Previous/index.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Page from '../Page'
+import ExhibitorList from '../../components/ExhibitorList'
+import './index.scss'
+
+const Previous = (props) => {
+
+  return (
+    <div className='Exhibitors-container'>
+      <Page { ...props } />
+      <ExhibitorList {...props} lastYear />
+    </div>
+  )
+}
+
+Previous.propTypes = {
+    head: PropTypes.object.isRequired,
+}
+
+export default Previous

--- a/src/layouts/Previous/index.scss
+++ b/src/layouts/Previous/index.scss
@@ -1,0 +1,15 @@
+@import "../../styles/variables";
+
+
+.Exhibitors-container {
+  padding: 3em 0em;
+  max-width: $page-width;
+  margin: auto;
+}
+
+
+@media screen and (max-width: $breakpoint-mobile-flipped){
+  .Exhibitors-container {
+    padding: 3em 1em;
+  }
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -21,6 +21,7 @@ import Exhibitors from "./layouts/Exhibitors"
 import Coffee from "./layouts/Coffee"
 import Diversitypage from "./layouts/Diversitypage"
 import Sustainabilitypage from "./layouts/Sustainabilitypage"
+import Previous from "./layouts/Previous"
 //PageSection is added as layout to avoid warnings from phenomic for having the
 //PageSections compoment that is used in ExhibitorInfo layout.
 //Phenomic complains about not finding PageSection otherwise as it
@@ -42,6 +43,7 @@ const PageContainer = (props) => (
       FAQpage,
       Plainpage,
       PageSection,
+      Previous,
       Exhibitors,
       Recruitmentpage,
       Coffee,


### PR DESCRIPTION
Added a question regarding last year's exhibitors in the FAQ and updated the FAQ to be able to display clickable links.

Updated the ExhibitorList component to take in the optional parameter lastYear to be able to list the previous year's participants. This can be viewed at /previous/.

Unfortunately since the fair dates are hard coded on the website the code looks at the previous _year_, not the previous year in terms of the fair (only problematic after the fair in november and december, but still). This could be solved by adding an endpoint in the api which you can get the different fair dates. Adding this to the api would also allow us to make the fair dates dynamic on the website and make them update directly when a new date is added in the database.