### PR TITLE
Update height for header image to fit link inside

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -15,7 +15,7 @@ $light-grey: #e4e4e4;
 
 // Layout
 $header-min-height: 300px;
-$header-height: 380px;
+$header-height: 520px;
 $footer-max-height: 128px;
 $mobile-edge: 1em;
 $page-width: 850px;


### PR DESCRIPTION
Fix for making the "Visit the virtual fair" link fit inside header image. 
On other pages than home page. 

![image](https://user-images.githubusercontent.com/62420861/141839098-6496f73c-a02a-4e54-a6df-7542def31d70.png)
