### PR TITLE
fixed contact us form width on mobile

### DIFF
--- a/src/components/EmailForm/index.scss
+++ b/src/components/EmailForm/index.scss
@@ -3,6 +3,7 @@
 
 .container {
     justify-content: center;
+    width: 100%;
 }
 
 .formContainer {
@@ -34,6 +35,7 @@ textarea {
     resize: none;
     font-family: $font-regular;
     font-size: $body-font-size;
+    width: 100%;
 }
 
 .sendButton {


### PR DESCRIPTION
Added width styling to the component EmailForm to fix the issue with the faq pages being formatted weirdly when pressing the Contact Us button

Before: 
![image (1)](https://user-images.githubusercontent.com/13528811/191055577-0ad2cb06-14ac-4964-82a8-7dbe011df098.png)

After:
<img width="960" alt="contact-us" src="https://user-images.githubusercontent.com/13528811/191055613-86711072-28ee-442e-ab31-f702da1037e5.PNG">
